### PR TITLE
chore: bump df

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 arrow = { version = "38.0.0" }
-datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "06e9f53637f20dd91bef43b74942ec36c38c22d5", default-features = false }
+datafusion = { git = "https://github.com/jiacai2050/arrow-datafusion.git", rev = "13314c37020b90246db9b80f8294370c06e61018", default-features = false }
 hashbrown = { version = "0.13.2" }


### PR DESCRIPTION
See: https://github.com/jiacai2050/arrow-datafusion/pull/1/files

Main changes are make page filter API public.