### PR TITLE
fix: find time range for projection

### DIFF
--- a/iox_query/src/logical_optimizer/handle_gapfill/range_predicate.rs
+++ b/iox_query/src/logical_optimizer/handle_gapfill/range_predicate.rs
@@ -33,16 +33,6 @@ impl TreeNodeVisitor for TimeRangeVisitor {
 
     fn pre_visit(&mut self, plan: &LogicalPlan) -> Result<VisitRecursion> {
         match plan {
-            LogicalPlan::Projection(p) => {
-                let idx = p.schema.index_of_column(&self.col)?;
-                match unwrap_alias(&p.expr[idx]) {
-                    Expr::Column(ref c) => {
-                        self.col = c.clone();
-                        Ok(VisitRecursion::Continue)
-                    }
-                    _ => Ok(VisitRecursion::Stop),
-                }
-            }
             LogicalPlan::Filter(f) => {
                 let range = self.range.clone();
                 let range = split_conjunction(&f.predicate)
@@ -67,6 +57,7 @@ impl TreeNodeVisitor for TimeRangeVisitor {
             }
             // These nodes do not alter their schema, so we can recurse through them
             LogicalPlan::Sort(_)
+            | LogicalPlan::Projection(_)
             | LogicalPlan::Repartition(_)
             | LogicalPlan::Limit(_)
             | LogicalPlan::Explain(_)


### PR DESCRIPTION
Schema of projection is only part of table's all schema, so when there is no timestamp column in projection, it will throw error `field not found`.