### PR TITLE
fix: use source schema to find time column instead of projected schema

### DIFF
--- a/iox_query/src/logical_optimizer/handle_gapfill/range_predicate.rs
+++ b/iox_query/src/logical_optimizer/handle_gapfill/range_predicate.rs
@@ -45,7 +45,7 @@ impl TreeNodeVisitor for TimeRangeVisitor {
             }
             LogicalPlan::TableScan(t) => {
                 let source_schema = t.source.schema();
-                let qualifier = t.table_name.clone();
+                let qualifier = &t.table_name;
                 let df_schema = DFSchema::new_with_metadata(
                     source_schema
                         .fields()

--- a/iox_query/src/logical_optimizer/handle_gapfill/range_predicate.rs
+++ b/iox_query/src/logical_optimizer/handle_gapfill/range_predicate.rs
@@ -45,11 +45,19 @@ impl TreeNodeVisitor for TimeRangeVisitor {
             }
             LogicalPlan::TableScan(t) => {
                 let source_schema = t.source.schema();
+                let qualifier = t.table_name.clone();
                 let df_schema = DFSchema::new_with_metadata(
                     source_schema
                         .fields()
                         .iter()
-                        .map(|f| DFField::from(f.clone()))
+                        .map(|f| {
+                            DFField::new(
+                                Some(qualifier.clone()),
+                                f.name(),
+                                f.data_type().clone(),
+                                f.is_nullable(),
+                            )
+                        })
                         .collect(),
                     source_schema.metadata().clone(),
                 )?;

--- a/iox_query/src/logical_optimizer/handle_gapfill/range_predicate.rs
+++ b/iox_query/src/logical_optimizer/handle_gapfill/range_predicate.rs
@@ -4,7 +4,7 @@ use std::ops::{Bound, Range};
 use datafusion::{
     common::{
         tree_node::{TreeNode, TreeNodeVisitor, VisitRecursion},
-        DFSchema,
+        DFField, DFSchema,
     },
     error::Result,
     logical_expr::{Between, BinaryExpr, LogicalPlan, Operator},
@@ -44,13 +44,22 @@ impl TreeNodeVisitor for TimeRangeVisitor {
                 Ok(VisitRecursion::Continue)
             }
             LogicalPlan::TableScan(t) => {
+                let source_schema = t.source.schema();
+                let df_schema = DFSchema::new_with_metadata(
+                    source_schema
+                        .fields()
+                        .iter()
+                        .map(|f| DFField::from(f.clone()))
+                        .collect(),
+                    source_schema.metadata().clone(),
+                )?;
                 let range = self.range.clone();
                 let range = t
                     .filters
                     .iter()
                     .flat_map(split_conjunction)
                     .try_fold(range, |range, expr| {
-                        range.with_expr(&t.projected_schema, &self.col, expr)
+                        range.with_expr(&df_schema, &self.col, expr)
                     })?;
                 self.range = range;
                 Ok(VisitRecursion::Continue)


### PR DESCRIPTION
See https://github.com/apache/incubator-horaedb/pull/1445

Projected schema may not contain all column used in query, such as:
```
select a from table where b > 1;
```
Only `a` is in projected schema.